### PR TITLE
Add non-root user

### DIFF
--- a/test-harness/Dockerfile-test-harness
+++ b/test-harness/Dockerfile-test-harness
@@ -42,3 +42,6 @@ RUN apt-get clean
 
 # Entrypoint for runtime pre-processing
 COPY ../docker-entrypoint-hdl.sh /usr/local/bin/docker-entrypoint.sh
+
+# Create a non-root user
+RUN useradd -ms /bin/bash user

--- a/test-harness/Dockerfile-test-harness-ubuntu22-04
+++ b/test-harness/Dockerfile-test-harness-ubuntu22-04
@@ -53,3 +53,6 @@ RUN apt-get clean
 
 # Entrypoint for runtime pre-processing
 COPY ../docker-entrypoint-hdl.sh /usr/local/bin/docker-entrypoint.sh
+
+# Create a non-root user
+RUN useradd -ms /bin/bash user


### PR DESCRIPTION
Our MATLAB license does not allow running MATLAB as root.
The non-root user "user" does not require a password when switching from the default "root" when the container is run.
Going back to "root" from "user" can be done using "exit".